### PR TITLE
Refine token activity rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# OpenAI-test
+# Sui Wallet Holdings Viewer
+
+This repository now hosts a single-page web application that inspects the
+fungible token balances inside any Sui wallet. The app is **read only** and
+runs entirely in the browser – it never signs or submits transactions. When you
+enter a wallet address the page queries Sui's public JSON-RPC endpoint to list
+all detected coin types with human readable balances and expandable activity
+history for each token, complete with coin artwork when available.
+
+## Running locally
+
+Because the site is static you only need a web server to test it locally. Any
+simple file server works:
+
+```bash
+python -m http.server 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser and
+load `index.html`.
+
+## Deploying to the web from GitHub
+
+The app is a static site, so you can publish it straight from your repository
+using GitHub Pages:
+
+1. Commit the project to a GitHub repository and push your branch.
+2. In the GitHub UI, go to **Settings → Pages**.
+3. Under **Build and deployment**, select **Deploy from a branch**.
+4. Choose the branch you pushed (for example `main`) and the `/` (root)
+   directory.
+5. Save. GitHub will build the static site automatically and give you a public
+   URL you can share to test the wallet reader in the browser.
+
+Alternatively, you can deploy the same static files to services like Vercel,
+Netlify, or Cloudflare Pages.
+
+## How it works
+
+* Submits `suix_getAllBalances` JSON-RPC requests to fetch all coin types owned
+  by an address.
+* Queries `suix_getCoinMetadata` for each coin type to resolve symbols, names,
+  icons, and decimals.
+* Pulls recent transactions that either send or receive assets for the wallet
+  with `suix_queryTransactionBlocks`, groups the balance changes per coin type,
+  sorts them by recency, and renders the latest entries in expandable panels
+  beneath each token row.
+* Converts the raw integer balances and balance deltas into human-friendly
+  amounts using the metadata and displays the results in a responsive table.
+
+## Notes
+
+* This is a client-side reader only; it does **not** connect to a wallet or
+  request any signing permissions.
+* The app requires the public Sui RPC endpoint to be reachable from the user's
+  browser. If the endpoint enforces CORS or rate limits, you may need to host a
+  proxy under your control.
+* Each token activity panel shows up to the 10 most recent balance changes for
+  that coin to keep the UI scannable.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,788 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sui Wallet Holdings Viewer</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1.25rem 3rem;
+        background: radial-gradient(circle at top, #1e293b, #0f172a 55%);
+      }
+
+      .app {
+        width: min(960px, 100%);
+        background: rgba(15, 23, 42, 0.75);
+        backdrop-filter: blur(18px);
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 2.5rem 2rem 2rem;
+        box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+      }
+
+      h1 {
+        margin: 0 0 1.5rem;
+        font-size: clamp(2rem, 3vw + 1rem, 3.2rem);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        color: #38bdf8;
+        text-align: center;
+      }
+
+      p.description {
+        margin: 0 auto 1.75rem;
+        max-width: 620px;
+        line-height: 1.6;
+        text-align: center;
+        color: #cbd5f5;
+      }
+
+      form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+        margin-bottom: 1.75rem;
+      }
+
+      input[type="text"] {
+        flex: 1 1 320px;
+        min-width: 240px;
+        padding: 0.85rem 1.1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.75);
+        color: inherit;
+        font-size: 1rem;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input[type="text"]:focus {
+        outline: none;
+        border-color: #38bdf8;
+        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      }
+
+      button {
+        padding: 0.85rem 1.5rem;
+        border-radius: 12px;
+        border: none;
+        background: linear-gradient(135deg, #22d3ee, #3b82f6);
+        color: #0f172a;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 20px rgba(56, 189, 248, 0.25);
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
+      }
+
+      .status {
+        min-height: 1.5rem;
+        text-align: center;
+        font-size: 0.95rem;
+        margin-bottom: 1rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(15, 23, 42, 0.6);
+        overflow: hidden;
+        border-radius: 12px;
+      }
+
+      thead {
+        background: rgba(56, 189, 248, 0.15);
+        color: #7dd3fc;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.75rem;
+      }
+
+      th,
+      td {
+        padding: 0.95rem 1rem;
+        text-align: left;
+      }
+
+      th.actions,
+      td.actions {
+        text-align: right;
+        width: 120px;
+      }
+
+      tbody tr:nth-child(even) {
+        background: rgba(15, 23, 42, 0.45);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.18);
+        color: #e0f2fe;
+        font-size: 0.78rem;
+        letter-spacing: 0.04em;
+      }
+
+      .token-info {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .token-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        overflow: hidden;
+        background: rgba(148, 163, 184, 0.25);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        color: #cbd5f5;
+        flex-shrink: 0;
+      }
+
+      .token-icon img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .token-symbol {
+        font-weight: 600;
+        font-size: 1rem;
+      }
+
+      .token-name {
+        font-size: 0.78rem;
+        color: #cbd5f5;
+        margin-top: 0.15rem;
+      }
+
+      .token-meta {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .expand-btn {
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: transparent;
+        color: inherit;
+        border-radius: 999px;
+        padding: 0.4rem 0.95rem;
+        font-size: 0.85rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .expand-btn svg {
+        width: 16px;
+        height: 16px;
+        transition: transform 0.2s ease;
+      }
+
+      tr.expanded .expand-btn svg {
+        transform: rotate(180deg);
+      }
+
+      .transaction-panel {
+        background: rgba(15, 23, 42, 0.75);
+        padding: 1.25rem 1.5rem 1.5rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.15);
+      }
+
+      .transaction-panel h3 {
+        margin: 0 0 0.75rem;
+        font-size: 0.95rem;
+        color: #38bdf8;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .tx-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.9rem;
+      }
+
+      .tx-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+        padding-bottom: 0.75rem;
+      }
+
+      .tx-item:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .tx-amount {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .tx-amount.positive {
+        color: #34d399;
+      }
+
+      .tx-amount.negative {
+        color: #f87171;
+      }
+
+      .tx-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        font-size: 0.8rem;
+        color: #cbd5f5;
+      }
+
+      .tx-meta a {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .tx-empty {
+        color: #94a3b8;
+        font-size: 0.9rem;
+        padding: 1rem 0 0.25rem;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 2.5rem 1rem 1.5rem;
+        color: #94a3b8;
+      }
+
+      @media (max-width: 720px) {
+        th,
+        td {
+          padding: 0.75rem 0.6rem;
+        }
+
+        table {
+          font-size: 0.9rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app">
+      <h1>Sui Wallet Holdings Viewer</h1>
+      <p class="description">
+        Inspect the fungible token balances of any Sui wallet. Enter an address
+        to fetch all coin types and their human-readable balances from the
+        public Sui RPC endpoint. This tool is fully client-side and read-only.
+      </p>
+      <form id="wallet-form">
+        <input
+          id="wallet-input"
+          type="text"
+          inputmode="latin"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="0x..."
+          aria-label="Sui wallet address"
+          required
+        />
+        <button type="submit">Load balances</button>
+      </form>
+      <div class="status" id="status"></div>
+      <div id="results"></div>
+    </main>
+    <template id="balances-template">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Token</th>
+            <th scope="col">Balance</th>
+            <th scope="col">Coin type</th>
+            <th scope="col" class="actions">Activity</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </template>
+    <template id="empty-template">
+      <div class="empty-state">No fungible token balances found for this wallet.</div>
+    </template>
+    <script>
+      const RPC_URL = "https://fullnode.mainnet.sui.io/";
+      const EXPLORER_BASE = "https://suiexplorer.com/txblock";
+      const MAX_TRANSACTIONS = 40;
+      const MAX_ACTIVITY_ROWS = 10;
+      const form = document.getElementById("wallet-form");
+      const input = document.getElementById("wallet-input");
+      const status = document.getElementById("status");
+      const results = document.getElementById("results");
+      const balancesTpl = document.getElementById("balances-template");
+      const emptyTpl = document.getElementById("empty-template");
+      const metadataCache = new Map();
+      const transactionCache = new Map();
+
+      async function fetchRpc(method, params) {
+        const response = await fetch(RPC_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: Date.now(),
+            method,
+            params,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`RPC call failed with ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (payload.error) {
+          throw new Error(payload.error.message || "Unexpected RPC error");
+        }
+
+        return payload.result;
+      }
+
+      async function getBalances(address) {
+        return fetchRpc("suix_getAllBalances", [address]);
+      }
+
+      async function getCoinMetadata(coinType) {
+        if (metadataCache.has(coinType)) {
+          return metadataCache.get(coinType);
+        }
+
+        try {
+          const metadata = await fetchRpc("suix_getCoinMetadata", [coinType]);
+          metadataCache.set(coinType, metadata);
+          return metadata;
+        } catch (error) {
+          console.warn("Failed to load metadata for", coinType, error);
+          metadataCache.set(coinType, null);
+          return null;
+        }
+      }
+
+      function normalizeAddress(raw) {
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          return "";
+        }
+
+        const lower = trimmed.toLowerCase();
+        return lower.startsWith("0x") ? lower : `0x${lower}`;
+      }
+
+      function formatWithDecimals(balance, decimals) {
+        const units = BigInt(balance);
+        if (!decimals) {
+          return units.toString();
+        }
+
+        const divisor = BigInt(10) ** BigInt(decimals);
+        const integerPart = units / divisor;
+        const fractionalPart = units % divisor;
+        if (fractionalPart === 0n) {
+          return integerPart.toString();
+        }
+
+        const paddedFraction = fractionalPart
+          .toString()
+          .padStart(Number(decimals), "0")
+          .replace(/0+$/, "");
+        return `${integerPart.toString()}.${paddedFraction}`;
+      }
+
+      function truncateMiddle(value, length = 10) {
+        if (!value || value.length <= length) {
+          return value;
+        }
+
+        const half = Math.floor((length - 3) / 2);
+        return `${value.slice(0, half)}...${value.slice(-half)}`;
+      }
+
+      function formatTimestamp(timestampMs) {
+        if (!timestampMs) {
+          return "Unknown time";
+        }
+
+        const date = new Date(Number(timestampMs));
+        if (Number.isNaN(date.getTime())) {
+          return "Unknown time";
+        }
+
+        return date.toLocaleString(undefined, {
+          hour12: false,
+          year: "numeric",
+          month: "short",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      function createTransactionPanel(transactions, decimals, symbol, coinType) {
+        const panel = document.createElement("div");
+        panel.className = "transaction-panel";
+
+        const heading = document.createElement("h3");
+        heading.textContent = "Recent transactions";
+        panel.appendChild(heading);
+
+        if (!transactions.length) {
+          const empty = document.createElement("div");
+          empty.className = "tx-empty";
+          empty.textContent = "No recent balance changes found for this token.";
+          panel.appendChild(empty);
+          return panel;
+        }
+
+        const displayed = transactions.slice(0, MAX_ACTIVITY_ROWS);
+        const list = document.createElement("ul");
+        list.className = "tx-list";
+
+        for (const tx of displayed) {
+          const item = document.createElement("li");
+          item.className = "tx-item";
+
+          const amountSpan = document.createElement("span");
+          amountSpan.className = "tx-amount";
+
+          const amountBigInt = BigInt(tx.amount);
+          const direction = amountBigInt >= 0n ? "in" : "out";
+          amountSpan.classList.add(direction === "in" ? "positive" : "negative");
+
+          const absolute = amountBigInt < 0n ? (-amountBigInt).toString() : amountBigInt.toString();
+          const formattedAmount = formatWithDecimals(absolute, decimals);
+          const tokenLabel = symbol || truncateMiddle(coinType, 12);
+          amountSpan.textContent = `${direction === "in" ? "+" : "-"}${formattedAmount} ${tokenLabel}`;
+
+          const meta = document.createElement("div");
+          meta.className = "tx-meta";
+
+          const directionLabel = document.createElement("span");
+          directionLabel.textContent = direction === "in" ? "Received" : "Sent";
+
+          const timeLabel = document.createElement("span");
+          timeLabel.textContent = formatTimestamp(tx.timestampMs);
+
+          const link = document.createElement("a");
+          link.href = `${EXPLORER_BASE}/${tx.digest}?network=mainnet`;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          link.textContent = truncateMiddle(tx.digest, 14);
+
+          meta.append(directionLabel, timeLabel, link);
+          item.append(amountSpan, meta);
+          list.appendChild(item);
+        }
+
+        panel.appendChild(list);
+        return panel;
+      }
+
+      function renderBalances(rows, transactionsByCoin) {
+        results.innerHTML = "";
+        if (!rows.length) {
+          results.appendChild(emptyTpl.content.cloneNode(true));
+          return;
+        }
+
+        const table = balancesTpl.content.cloneNode(true);
+        const tbody = table.querySelector("tbody");
+        for (const row of rows) {
+          const tr = document.createElement("tr");
+          tr.className = "token-row";
+          const tokenCell = document.createElement("td");
+          const balanceCell = document.createElement("td");
+          const typeCell = document.createElement("td");
+          const actionCell = document.createElement("td");
+          actionCell.className = "actions";
+
+          const tokenInfo = document.createElement("div");
+          tokenInfo.className = "token-info";
+
+          const iconWrapper = document.createElement("span");
+          iconWrapper.className = "token-icon";
+          if (row.iconUrl) {
+            const img = document.createElement("img");
+            img.src = row.iconUrl;
+            img.alt = row.symbol ? `${row.symbol} logo` : "Token logo";
+            img.loading = "lazy";
+            iconWrapper.appendChild(img);
+          } else {
+            iconWrapper.textContent = row.symbol?.slice(0, 3) || "?";
+          }
+
+          const meta = document.createElement("div");
+          meta.className = "token-meta";
+          const symbolEl = document.createElement("span");
+          symbolEl.className = "token-symbol";
+          symbolEl.textContent = row.symbol || "Unknown";
+          meta.appendChild(symbolEl);
+          if (row.name) {
+            const nameEl = document.createElement("span");
+            nameEl.className = "token-name";
+            nameEl.textContent = row.name;
+            meta.appendChild(nameEl);
+          }
+
+          tokenInfo.append(iconWrapper, meta);
+          tokenCell.appendChild(tokenInfo);
+          balanceCell.textContent = row.displayBalance;
+          if (row.symbol) {
+            balanceCell.textContent += ` ${row.symbol}`;
+          }
+          typeCell.textContent = row.coinType;
+          typeCell.title = row.coinType;
+
+          const expandBtn = document.createElement("button");
+          expandBtn.type = "button";
+          expandBtn.className = "expand-btn";
+          expandBtn.innerHTML = `
+            <span>View activity</span>
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.22 7.22a.75.75 0 0 1 1.06 0L10 10.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 8.28a.75.75 0 0 1 0-1.06z" clip-rule="evenodd"></path>
+            </svg>
+          `;
+          expandBtn.setAttribute("aria-expanded", "false");
+          actionCell.appendChild(expandBtn);
+
+          const detailTr = document.createElement("tr");
+          const detailTd = document.createElement("td");
+          detailTd.colSpan = 4;
+          const transactions = transactionsByCoin.get(row.coinType) || [];
+          detailTd.appendChild(
+            createTransactionPanel(transactions, row.decimals, row.symbol, row.coinType)
+          );
+          detailTr.appendChild(detailTd);
+          detailTr.style.display = "none";
+
+          expandBtn.addEventListener("click", () => {
+            const isExpanded = tr.classList.toggle("expanded");
+            detailTr.style.display = isExpanded ? "table-row" : "none";
+            expandBtn.setAttribute("aria-expanded", String(isExpanded));
+            expandBtn.querySelector("span").textContent = isExpanded
+              ? "Hide activity"
+              : "View activity";
+          });
+
+          tr.append(tokenCell, balanceCell, typeCell, actionCell);
+          tbody.append(tr, detailTr);
+        }
+
+        results.appendChild(table);
+      }
+
+      function extractOwnerAddress(owner) {
+        if (!owner) {
+          return null;
+        }
+
+        if (typeof owner === "string") {
+          return owner;
+        }
+
+        if (owner.AddressOwner) {
+          return owner.AddressOwner;
+        }
+
+        if (owner.GasOwner) {
+          return owner.GasOwner;
+        }
+
+        if (owner.ObjectOwner) {
+          return owner.ObjectOwner;
+        }
+
+        return null;
+      }
+
+      async function getTransactions(address) {
+        if (transactionCache.has(address)) {
+          return transactionCache.get(address);
+        }
+
+        const query = {
+          filter: {
+            Any: [{ FromAddress: address }, { ToAddress: address }],
+          },
+          options: {
+            showBalanceChanges: true,
+            showEffects: true,
+            showInput: false,
+            showEvents: false,
+            showObjectChanges: false,
+          },
+        };
+
+        try {
+          const response = await fetchRpc("suix_queryTransactionBlocks", [
+            query,
+            null,
+            MAX_TRANSACTIONS,
+            true,
+          ]);
+          const transactions = response?.data ?? [];
+          transactionCache.set(address, transactions);
+          return transactions;
+        } catch (error) {
+          console.warn("Failed to load transactions", error);
+          transactionCache.set(address, []);
+          return [];
+        }
+      }
+
+      function groupTransactionsByCoin(transactions, address) {
+        const map = new Map();
+        const normalizedAddress = normalizeAddress(address);
+
+        for (const tx of transactions) {
+          const digest = tx.digest;
+          const timestampMs = tx.timestampMs ?? null;
+          const balanceChanges = tx.balanceChanges || [];
+
+          for (const change of balanceChanges) {
+            const ownerAddress = normalizeAddress(extractOwnerAddress(change.owner || null) || "");
+            if (!ownerAddress || ownerAddress !== normalizedAddress) {
+              continue;
+            }
+
+            const coinType = change.coinType;
+            if (!coinType) {
+              continue;
+            }
+
+            if (change.amount === undefined || change.amount === null) {
+              continue;
+            }
+
+            if (!map.has(coinType)) {
+              map.set(coinType, []);
+            }
+
+            const entry = {
+              digest,
+              timestampMs,
+              amount: change.amount,
+            };
+            map.get(coinType).push(entry);
+          }
+        }
+
+        for (const [coinType, entries] of map.entries()) {
+          entries.sort((a, b) => {
+            const aTime = a.timestampMs ? Number(a.timestampMs) : 0;
+            const bTime = b.timestampMs ? Number(b.timestampMs) : 0;
+            return bTime - aTime;
+          });
+          map.set(coinType, entries);
+        }
+
+        return map;
+      }
+
+      async function handleSubmit(event) {
+        event.preventDefault();
+        const address = normalizeAddress(input.value);
+        if (!address) {
+          return;
+        }
+
+        status.textContent = "Fetching balances...";
+        status.style.color = "#38bdf8";
+        results.innerHTML = "";
+        form.querySelector("button").disabled = true;
+
+        try {
+          const [balances, transactions] = await Promise.all([
+            getBalances(address),
+            getTransactions(address),
+          ]);
+          const transactionsByCoin = groupTransactionsByCoin(transactions, address);
+          const rows = await Promise.all(
+            (balances || []).map(async (balance) => {
+              const metadata = await getCoinMetadata(balance.coinType);
+              const decimals = metadata?.decimals ?? 0;
+              const symbol = metadata?.symbol ?? null;
+              const displayBalance = formatWithDecimals(balance.totalBalance, decimals);
+
+              return {
+                coinType: balance.coinType,
+                displayBalance,
+                symbol,
+                name: metadata?.name ?? null,
+                iconUrl: metadata?.iconUrl ?? null,
+                decimals,
+                rawBalance: balance.totalBalance,
+              };
+            })
+          );
+
+          const sortedRows = rows.sort((a, b) => {
+            try {
+              const diff = BigInt(b.rawBalance) - BigInt(a.rawBalance);
+              if (diff > 0n) return 1;
+              if (diff < 0n) return -1;
+            } catch (error) {
+              // ignore
+            }
+            return 0;
+          }).map(({ rawBalance, ...rest }) => rest);
+
+          renderBalances(sortedRows, transactionsByCoin);
+          status.textContent = `Loaded ${sortedRows.length} token${sortedRows.length === 1 ? "" : "s"}.`;
+          status.style.color = "#34d399";
+        } catch (error) {
+          console.error(error);
+          status.textContent = error.message || "Something went wrong.";
+          status.style.color = "#f87171";
+        } finally {
+          form.querySelector("button").disabled = false;
+        }
+      }
+
+      form.addEventListener("submit", handleSubmit);
+    </script>
+  </body>
+</html>

--- a/wallet_reader.py
+++ b/wallet_reader.py
@@ -1,0 +1,165 @@
+"""Sui wallet reader CLI.
+
+This script provides read-only access to Sui wallets by querying the public
+JSON-RPC endpoint. Given a wallet address it fetches the balances of all coins
+held by the address and prints a readable summary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Iterable, List, Optional
+
+JSON_RPC_ID = 1
+
+SUI_NETWORK_ENDPOINTS: Dict[str, str] = {
+    "mainnet": "https://fullnode.mainnet.sui.io:443",
+    "testnet": "https://fullnode.testnet.sui.io:443",
+    "devnet": "https://fullnode.devnet.sui.io:443",
+}
+
+
+@dataclass
+class CoinBalance:
+    """Represents a coin balance for a Sui address."""
+
+    coin_type: str
+    total_balance: int
+    symbol: Optional[str]
+    decimals: Optional[int]
+
+    @property
+    def display_symbol(self) -> str:
+        if self.symbol:
+            return self.symbol
+        # Derive symbol from coin type last segment if metadata is missing.
+        return self.coin_type.split("::")[-1]
+
+    def formatted_balance(self) -> str:
+        if self.decimals is None or self.decimals < 0:
+            return str(self.total_balance)
+        scaled = self.total_balance / (10 ** self.decimals)
+        return f"{scaled:,.{min(self.decimals, 9)}f}"
+
+
+class SuiRpcError(RuntimeError):
+    """Raised when the Sui JSON-RPC endpoint responds with an error."""
+
+
+class SuiWalletReader:
+    """Client for reading Sui wallet balances via JSON-RPC."""
+
+    def __init__(self, network: str = "mainnet") -> None:
+        if network not in SUI_NETWORK_ENDPOINTS:
+            available = ", ".join(sorted(SUI_NETWORK_ENDPOINTS))
+            raise ValueError(
+                f"Unknown network '{network}'. Available networks: {available}"
+            )
+        self.network = network
+        self.endpoint = SUI_NETWORK_ENDPOINTS[network]
+
+    def read_balances(self, address: str) -> List[CoinBalance]:
+        balances = self._call_rpc("suix_getAllBalances", [address])
+        coins: List[CoinBalance] = []
+        for entry in balances:
+            coin_type = entry.get("coinType")
+            raw_balance = entry.get("totalBalance")
+            if coin_type is None or raw_balance is None:
+                # Skip malformed entries.
+                continue
+            metadata = self._coin_metadata(coin_type)
+            coins.append(
+                CoinBalance(
+                    coin_type=coin_type,
+                    total_balance=int(raw_balance),
+                    symbol=metadata.get("symbol") if metadata else None,
+                    decimals=metadata.get("decimals") if metadata else None,
+                )
+            )
+        return coins
+
+    def _call_rpc(self, method: str, params: Iterable[object]) -> object:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": list(params),
+                "id": JSON_RPC_ID,
+            }
+        ).encode("utf-8")
+
+        request = urllib.request.Request(
+            self.endpoint, data=payload, headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except urllib.error.URLError as exc:  # pragma: no cover - network errors
+            raise ConnectionError(
+                f"Failed to connect to Sui endpoint '{self.endpoint}': {exc}"
+            ) from exc
+
+        if "error" in data:
+            error = data["error"]
+            message = error.get("message", "Unknown error")
+            raise SuiRpcError(f"RPC error calling {method}: {message}")
+        return data.get("result")
+
+    @lru_cache(maxsize=128)
+    def _coin_metadata(self, coin_type: str) -> Dict[str, object]:
+        try:
+            metadata = self._call_rpc("suix_getCoinMetadata", [coin_type])
+        except SuiRpcError:
+            # Some coins may not have metadata. Return empty dict to avoid noisy output.
+            return {}
+        if metadata is None:
+            return {}
+        return metadata
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read holdings for a Sui wallet.")
+    parser.add_argument(
+        "address",
+        help="Sui wallet address (0x...) to inspect",
+    )
+    parser.add_argument(
+        "--network",
+        default="mainnet",
+        choices=sorted(SUI_NETWORK_ENDPOINTS),
+        help="Sui network to query (default: mainnet)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    reader = SuiWalletReader(network=args.network)
+    try:
+        balances = reader.read_balances(args.address)
+    except (ConnectionError, SuiRpcError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if not balances:
+        print("No balances found for this address.")
+        return 0
+
+    print(f"Holdings for address {args.address} on {args.network}:")
+    print("-" * 60)
+    for coin in balances:
+        amount = coin.formatted_balance()
+        symbol = coin.display_symbol
+        print(f"{symbol:<20} {amount:>20}  ({coin.coin_type})")
+    print("-" * 60)
+    print(f"Total coins: {len(balances)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- limit per-token activity panels to the most recent entries and append token symbols to balance figures
- sort grouped balance changes chronologically, render balance rows after concurrent metadata lookups, and keep the UI focused on higher balances
- document the recency sorting and activity entry cap in the README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e60a6cd11c832f8775568346222cde