### PR TITLE
Enhance CLI wallet reader with protocol position scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# OpenAI-test
+# Sui Wallet Holdings Viewer
+
+This repository now hosts a single-page web application that inspects the
+fungible token balances and protocol positions inside any Sui wallet. The app
+is **read only** and runs entirely in the browser – it never signs or submits
+transactions. When you enter a wallet address the page queries Sui's public
+JSON-RPC endpoint to list all detected coin types with human readable balances,
+expandable activity history for each token, and a dedicated section that
+summarises positions held in well-known protocols such as Cetus, Suilend, Navi
+Protocol, and Bluefin.
+
+## Running locally
+
+Because the site is static you only need a web server to test it locally. Any
+simple file server works:
+
+```bash
+python -m http.server 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser and
+load `index.html`.
+
+### Command-line wallet reader
+
+The repository also includes a Python CLI, `wallet_reader.py`, which mirrors the
+browser experience. It prints coin balances with recent activity and now scans
+owned objects to surface protocol positions (Cetus, Suilend, Navi Protocol, and
+Bluefin) for the supplied address:
+
+```bash
+python wallet_reader.py 0xYOURADDRESS
+```
+
+Use `--network` to target `mainnet`, `testnet`, or `devnet`.
+
+## Deploying to the web from GitHub
+
+The app is a static site, so you can publish it straight from your repository
+using GitHub Pages:
+
+1. Commit the project to a GitHub repository and push your branch.
+2. In the GitHub UI, go to **Settings → Pages**.
+3. Under **Build and deployment**, select **Deploy from a branch**.
+4. Choose the branch you pushed (for example `main`) and the `/` (root)
+   directory.
+5. Save. GitHub will build the static site automatically and give you a public
+   URL you can share to test the wallet reader in the browser.
+
+Alternatively, you can deploy the same static files to services like Vercel,
+Netlify, or Cloudflare Pages.
+
+## How it works
+
+* Submits `suix_getAllBalances` JSON-RPC requests to fetch all coin types owned
+  by an address.
+* Queries `suix_getCoinMetadata` for each coin type to resolve symbols, names,
+  icons, and decimals.
+* Pulls recent transactions that either send or receive assets for the wallet
+  with `suix_queryTransactionBlocks`, groups the balance changes per coin type,
+  sorts them by recency, and renders the latest entries in expandable panels
+  beneath each token row.
+* Fetches owned objects via `suix_getOwnedObjects`, filters for well-known DeFi
+  packages, and formats any detected liquidity, lending, or perpetual position
+  metadata into protocol cards shown beneath the token table.
+* Converts the raw integer balances and balance deltas into human-friendly
+  amounts using the metadata and displays the results in a responsive table.
+
+## Notes
+
+* This is a client-side reader only; it does **not** connect to a wallet or
+  request any signing permissions.
+* The app requires the public Sui RPC endpoint to be reachable from the user's
+  browser. If the endpoint enforces CORS or rate limits, you may need to host a
+  proxy under your control.
+* Each token activity panel shows up to the 10 most recent balance changes for
+  that coin to keep the UI scannable.
+* Protocol detection relies on known object type patterns for Cetus, Suilend,
+  Navi Protocol, and Bluefin. Objects that don't expose meaningful metadata may
+  appear with generic labels until the underlying packages publish richer
+  display data.
+* Older browsers that lack native `BigInt` support will still load the page,
+  but large integer balances are rounded using regular JavaScript numbers. A
+  current Chromium, Firefox, or Safari release provides the most accurate
+  formatting.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1514 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sui Wallet Holdings Viewer</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1.25rem 3rem;
+        background: radial-gradient(circle at top, #1e293b, #0f172a 55%);
+      }
+
+      .app {
+        width: min(960px, 100%);
+        background: rgba(15, 23, 42, 0.75);
+        backdrop-filter: blur(18px);
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 2.5rem 2rem 2rem;
+        box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+      }
+
+      h1 {
+        margin: 0 0 1.5rem;
+        font-size: clamp(2rem, 3vw + 1rem, 3.2rem);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        color: #38bdf8;
+        text-align: center;
+      }
+
+      p.description {
+        margin: 0 auto 1.75rem;
+        max-width: 620px;
+        line-height: 1.6;
+        text-align: center;
+        color: #cbd5f5;
+      }
+
+      form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+        margin-bottom: 1.75rem;
+      }
+
+      input[type="text"] {
+        flex: 1 1 320px;
+        min-width: 240px;
+        padding: 0.85rem 1.1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.75);
+        color: inherit;
+        font-size: 1rem;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input[type="text"]:focus {
+        outline: none;
+        border-color: #38bdf8;
+        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      }
+
+      button {
+        padding: 0.85rem 1.5rem;
+        border-radius: 12px;
+        border: none;
+        background: linear-gradient(135deg, #22d3ee, #3b82f6);
+        color: #0f172a;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 20px rgba(56, 189, 248, 0.25);
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
+      }
+
+      .status {
+        min-height: 1.5rem;
+        text-align: center;
+        font-size: 0.95rem;
+        margin-bottom: 1rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(15, 23, 42, 0.6);
+        overflow: hidden;
+        border-radius: 12px;
+      }
+
+      thead {
+        background: rgba(56, 189, 248, 0.15);
+        color: #7dd3fc;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.75rem;
+      }
+
+      th,
+      td {
+        padding: 0.95rem 1rem;
+        text-align: left;
+      }
+
+      th.actions,
+      td.actions {
+        text-align: right;
+        width: 120px;
+      }
+
+      tbody tr:nth-child(even) {
+        background: rgba(15, 23, 42, 0.45);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.18);
+        color: #e0f2fe;
+        font-size: 0.78rem;
+        letter-spacing: 0.04em;
+      }
+
+      .token-info {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .token-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        overflow: hidden;
+        background: rgba(148, 163, 184, 0.25);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        color: #cbd5f5;
+        flex-shrink: 0;
+      }
+
+      .token-icon img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .token-symbol {
+        font-weight: 600;
+        font-size: 1rem;
+      }
+
+      .token-name {
+        font-size: 0.78rem;
+        color: #cbd5f5;
+        margin-top: 0.15rem;
+      }
+
+      .token-meta {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .expand-btn {
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: transparent;
+        color: inherit;
+        border-radius: 999px;
+        padding: 0.4rem 0.95rem;
+        font-size: 0.85rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .expand-btn svg {
+        width: 16px;
+        height: 16px;
+        transition: transform 0.2s ease;
+      }
+
+      tr.expanded .expand-btn svg {
+        transform: rotate(180deg);
+      }
+
+      .transaction-panel {
+        background: rgba(15, 23, 42, 0.75);
+        padding: 1.25rem 1.5rem 1.5rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.15);
+      }
+
+      .transaction-panel h3 {
+        margin: 0 0 0.75rem;
+        font-size: 0.95rem;
+        color: #38bdf8;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .tx-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.9rem;
+      }
+
+      .tx-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+        padding-bottom: 0.75rem;
+      }
+
+      .tx-item:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .tx-amount {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+
+      .tx-amount.positive {
+        color: #34d399;
+      }
+
+      .tx-amount.negative {
+        color: #f87171;
+      }
+
+      .tx-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        font-size: 0.8rem;
+        color: #cbd5f5;
+      }
+
+      .tx-meta a {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .tx-empty {
+        color: #94a3b8;
+        font-size: 0.9rem;
+        padding: 1rem 0 0.25rem;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 2.5rem 1rem 1.5rem;
+        color: #94a3b8;
+      }
+
+      .wallet-section {
+        margin-top: 2.5rem;
+      }
+
+      .wallet-section:first-of-type {
+        margin-top: 0;
+      }
+
+      .section-heading {
+        margin: 0;
+        font-size: 1.15rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: #7dd3fc;
+      }
+
+      .wallet-section table {
+        margin-top: 1.25rem;
+      }
+
+      .protocol-empty {
+        margin-top: 1.25rem;
+        padding: 1.5rem 1rem;
+        border-radius: 12px;
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        text-align: center;
+        color: #94a3b8;
+        background: rgba(15, 23, 42, 0.45);
+      }
+
+      .protocol-grid {
+        margin-top: 1.5rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .protocol-card {
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.65);
+        padding: 1.4rem 1.35rem 1.2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+      }
+
+      .protocol-card-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .protocol-card-title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #e0f2fe;
+      }
+
+      .protocol-card-label {
+        font-size: 0.85rem;
+        color: #cbd5f5;
+      }
+
+      .protocol-metrics {
+        margin: 0;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.65rem 1rem;
+      }
+
+      .protocol-metrics dt {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #94a3b8;
+      }
+
+      .protocol-metrics dd {
+        margin: 0;
+        font-size: 0.92rem;
+        color: #e2e8f0;
+        font-weight: 500;
+      }
+
+      .protocol-card-footer {
+        margin-top: auto;
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .protocol-card-footer a {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 0.85rem;
+      }
+
+      .protocol-card-footer a:hover {
+        text-decoration: underline;
+      }
+
+      @media (max-width: 720px) {
+        th,
+        td {
+          padding: 0.75rem 0.6rem;
+        }
+
+        table {
+          font-size: 0.9rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app">
+      <h1>Sui Wallet Holdings Viewer</h1>
+      <p class="description">
+        Inspect the fungible token balances of any Sui wallet. Enter an address
+        to fetch all coin types and their human-readable balances from the
+        public Sui RPC endpoint. This tool is fully client-side and read-only.
+      </p>
+      <form id="wallet-form">
+        <input
+          id="wallet-input"
+          type="text"
+          inputmode="latin"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="0x..."
+          aria-label="Sui wallet address"
+          required
+        />
+        <button type="submit">Load balances</button>
+      </form>
+      <div class="status" id="status"></div>
+      <div id="results"></div>
+    </main>
+    <template id="balances-template">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Token</th>
+            <th scope="col">Balance</th>
+            <th scope="col">Coin type</th>
+            <th scope="col" class="actions">Activity</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </template>
+    <template id="empty-template">
+      <div class="empty-state">No fungible token balances found for this wallet.</div>
+    </template>
+    <script>
+      const RPC_URL = "https://fullnode.mainnet.sui.io/";
+      const EXPLORER_BASE = "https://suiexplorer.com/txblock";
+      const MAX_TRANSACTIONS = 40;
+      const MAX_ACTIVITY_ROWS = 10;
+      const form = document.getElementById("wallet-form");
+      const input = document.getElementById("wallet-input");
+      const status = document.getElementById("status");
+      const results = document.getElementById("results");
+      const balancesTpl = document.getElementById("balances-template");
+      const emptyTpl = document.getElementById("empty-template");
+      const metadataCache = new Map();
+      const transactionCache = new Map();
+      const hasBigInt = typeof BigInt === "function";
+      const BIGINT_ZERO = hasBigInt ? BigInt(0) : 0;
+      const EXPLORER_OBJECT_BASE = "https://suiexplorer.com/object";
+      const OBJECT_PAGE_LIMIT = 5;
+      const OBJECT_PAGE_SIZE = 50;
+      const COIN_TYPE_PREFIX = "0x2::coin::Coin<";
+      const PREFERRED_FIELD_KEYS = [
+        "liquidity",
+        "amount",
+        "amount_a",
+        "amount_b",
+        "balance",
+        "borrowed",
+        "supplied",
+        "collateral",
+        "debt",
+        "principal",
+        "side",
+        "size",
+        "entry_price",
+        "leverage",
+        "apr",
+        "apy",
+        "coin_a",
+        "coin_b",
+        "pool_id",
+        "pool",
+        "index",
+      ];
+      const MAX_FIELD_RESULTS = 6;
+      const PROTOCOL_DEFINITIONS = [
+        {
+          name: "Cetus",
+          patterns: ["::cetus", "::clmm"],
+          preferredFields: [
+            "coin_a",
+            "coin_b",
+            "liquidity",
+            "amount_a",
+            "amount_b",
+          ],
+        },
+        {
+          name: "Suilend",
+          patterns: ["::suilend"],
+          preferredFields: ["supplied", "borrowed", "collateral", "debt"],
+        },
+        {
+          name: "Navi Protocol",
+          patterns: ["::navi"],
+          preferredFields: ["supplied", "borrowed", "collateral", "apy"],
+        },
+        {
+          name: "Bluefin",
+          patterns: ["::bluefin", "::perps", "::perpetual"],
+          preferredFields: ["side", "size", "entry_price", "leverage"],
+        },
+      ];
+
+      function toNumeric(value) {
+        if (value === undefined || value === null) {
+          return hasBigInt ? BIGINT_ZERO : 0;
+        }
+
+        try {
+          return hasBigInt ? BigInt(value) : Number(value);
+        } catch (error) {
+          return hasBigInt ? BIGINT_ZERO : 0;
+        }
+      }
+
+      async function fetchRpc(method, params) {
+        const response = await fetch(RPC_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: Date.now(),
+            method,
+            params,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`RPC call failed with ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (payload.error) {
+          throw new Error(payload.error.message || "Unexpected RPC error");
+        }
+
+        return payload.result;
+      }
+
+      async function getBalances(address) {
+        return fetchRpc("suix_getAllBalances", [address]);
+      }
+
+      async function getCoinMetadata(coinType) {
+        if (metadataCache.has(coinType)) {
+          return metadataCache.get(coinType);
+        }
+
+        try {
+          const metadata = await fetchRpc("suix_getCoinMetadata", [coinType]);
+          metadataCache.set(coinType, metadata);
+          return metadata;
+        } catch (error) {
+          console.warn("Failed to load metadata for", coinType, error);
+          metadataCache.set(coinType, null);
+          return null;
+        }
+      }
+
+      function normalizeAddress(raw) {
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          return "";
+        }
+
+        const lower = trimmed.toLowerCase();
+        return lower.startsWith("0x") ? lower : `0x${lower}`;
+      }
+
+      function formatWithDecimals(balance, decimals) {
+        const decimalCount = Number(decimals) || 0;
+
+        if (!hasBigInt) {
+          const divisor = decimalCount ? Math.pow(10, decimalCount) : 1;
+          const numericBalance = Number(balance) / divisor;
+
+          if (!Number.isFinite(numericBalance)) {
+            return String(balance);
+          }
+
+          if (!decimalCount) {
+            return Math.trunc(numericBalance).toString();
+          }
+
+          const fixed = numericBalance.toFixed(Math.min(decimalCount, 6));
+          return fixed.replace(/\.0+$/, "");
+        }
+
+        const units = BigInt(balance);
+        if (!decimalCount) {
+          return units.toString();
+        }
+
+        const divisor = BigInt(10) ** BigInt(decimalCount);
+        const integerPart = units / divisor;
+        const fractionalPart = units % divisor;
+        if (fractionalPart === BIGINT_ZERO) {
+          return integerPart.toString();
+        }
+
+        const paddedFraction = fractionalPart
+          .toString()
+          .padStart(decimalCount, "0")
+          .replace(/0+$/, "");
+        return `${integerPart.toString()}.${paddedFraction}`;
+      }
+
+      function truncateMiddle(value, length = 10) {
+        if (!value || value.length <= length) {
+          return value;
+        }
+
+        const half = Math.floor((length - 3) / 2);
+        return `${value.slice(0, half)}...${value.slice(-half)}`;
+      }
+
+      function formatTimestamp(timestampMs) {
+        if (!timestampMs) {
+          return "Unknown time";
+        }
+
+        const date = new Date(Number(timestampMs));
+        if (Number.isNaN(date.getTime())) {
+          return "Unknown time";
+        }
+
+        return date.toLocaleString(undefined, {
+          hour12: false,
+          year: "numeric",
+          month: "short",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      function toTitleCase(value) {
+        if (!value) {
+          return "";
+        }
+
+        return value
+          .replace(/[_-]+/g, " ")
+          .replace(/\s+/g, " ")
+          .trim()
+          .replace(/\b\w/g, (char) => char.toUpperCase());
+      }
+
+      function identifyProtocolByType(type) {
+        if (!type) {
+          return null;
+        }
+
+        const lower = type.toLowerCase();
+        for (const definition of PROTOCOL_DEFINITIONS) {
+          if (definition.patterns.some((pattern) => lower.includes(pattern))) {
+            return definition;
+          }
+        }
+
+        return null;
+      }
+
+      function valueToString(value) {
+        if (value === null || value === undefined) {
+          return null;
+        }
+
+        if (typeof value === "bigint") {
+          return value.toString();
+        }
+
+        if (typeof value === "number") {
+          return Number.isFinite(value) ? value.toString() : null;
+        }
+
+        if (typeof value === "string") {
+          return value;
+        }
+
+        if (Array.isArray(value)) {
+          const formatted = value
+            .map((item) => valueToString(item))
+            .filter(Boolean);
+          return formatted.length ? formatted.join(", ") : null;
+        }
+
+        if (typeof value === "object") {
+          if (typeof value.id === "string") {
+            return value.id;
+          }
+
+          if (typeof value.objectId === "string") {
+            return value.objectId;
+          }
+
+          if (value.fields) {
+            return valueToString(value.fields);
+          }
+
+          const primitives = [];
+          for (const [key, nested] of Object.entries(value)) {
+            const formatted = valueToString(nested);
+            if (formatted) {
+              primitives.push(`${toTitleCase(key)}: ${formatted}`);
+            }
+            if (primitives.length >= 2) {
+              break;
+            }
+          }
+
+          return primitives.length ? primitives.join(" • ") : null;
+        }
+
+        return String(value);
+      }
+
+      function findFieldValue(fields, targetKey) {
+        if (!fields || typeof fields !== "object") {
+          return undefined;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(fields, targetKey)) {
+          return fields[targetKey];
+        }
+
+        for (const value of Object.values(fields)) {
+          if (value && typeof value === "object") {
+            const nested = findFieldValue(value, targetKey);
+            if (nested !== undefined) {
+              return nested;
+            }
+          }
+        }
+
+        return undefined;
+      }
+
+      function collectFieldEntries(fields, definition) {
+        const metrics = [];
+        const seenKeys = new Set();
+        if (!fields || typeof fields !== "object") {
+          return metrics;
+        }
+
+        const prioritizedKeys = [
+          ...(definition && definition.preferredFields
+            ? definition.preferredFields
+            : []),
+          ...PREFERRED_FIELD_KEYS,
+        ];
+
+        for (const key of prioritizedKeys) {
+          if (seenKeys.has(key)) {
+            continue;
+          }
+
+          const value = findFieldValue(fields, key);
+          const formatted = valueToString(value);
+          if (formatted) {
+            metrics.push({ label: toTitleCase(key), value: formatted });
+            seenKeys.add(key);
+          }
+
+          if (metrics.length >= MAX_FIELD_RESULTS) {
+            return metrics;
+          }
+        }
+
+        for (const [key, value] of Object.entries(fields)) {
+          if (seenKeys.has(key)) {
+            continue;
+          }
+
+          if (typeof value === "object" && value !== null) {
+            const formatted = valueToString(value);
+            if (!formatted) {
+              continue;
+            }
+            metrics.push({ label: toTitleCase(key), value: formatted });
+          } else {
+            const formatted = valueToString(value);
+            if (!formatted) {
+              continue;
+            }
+            metrics.push({ label: toTitleCase(key), value: formatted });
+          }
+
+          if (metrics.length >= MAX_FIELD_RESULTS) {
+            break;
+          }
+        }
+
+        return metrics;
+      }
+
+      function extractDisplayLabel(display) {
+        const data = display && display.data ? display.data : display;
+        if (!data || typeof data !== "object") {
+          return null;
+        }
+
+        for (const key of ["name", "title", "label"]) {
+          const value = data[key];
+          if (typeof value === "string" && value.trim()) {
+            return value.trim();
+          }
+        }
+
+        return null;
+      }
+
+      function createDisplayEntries(display) {
+        const data = display && display.data ? display.data : display;
+        if (!data || typeof data !== "object") {
+          return [];
+        }
+
+        const metrics = [];
+        for (const [key, value] of Object.entries(data)) {
+          if (["name", "title", "label"].includes(key)) {
+            continue;
+          }
+
+          const formatted = valueToString(value);
+          if (!formatted) {
+            continue;
+          }
+
+          metrics.push({ label: toTitleCase(key), value: formatted });
+          if (metrics.length >= MAX_FIELD_RESULTS) {
+            break;
+          }
+        }
+
+        return metrics;
+      }
+
+      function shortenTypeName(value) {
+        if (!value || typeof value !== "string") {
+          return value;
+        }
+
+        const withoutGenerics = value.replace(/<.*>/, "");
+        const parts = withoutGenerics.split("::");
+        return parts[parts.length - 1] || value;
+      }
+
+      function deriveProtocolLabel(definition, fields, type) {
+        if (fields && typeof fields === "object") {
+          const coinA =
+            findFieldValue(fields, "coin_a") ||
+            findFieldValue(fields, "coinA") ||
+            findFieldValue(fields, "token_a");
+          const coinB =
+            findFieldValue(fields, "coin_b") ||
+            findFieldValue(fields, "coinB") ||
+            findFieldValue(fields, "token_b");
+          if (coinA && coinB) {
+            const formattedA = valueToString(coinA) || shortenTypeName(String(coinA));
+            const formattedB = valueToString(coinB) || shortenTypeName(String(coinB));
+            if (formattedA && formattedB) {
+              return `${shortenTypeName(formattedA)} / ${shortenTypeName(formattedB)}`;
+            }
+          }
+
+          const market =
+            findFieldValue(fields, "market") ||
+            findFieldValue(fields, "pool_id") ||
+            findFieldValue(fields, "pool");
+          if (market) {
+            const formattedMarket = valueToString(market);
+            if (formattedMarket) {
+              return formattedMarket;
+            }
+          }
+
+          const asset =
+            findFieldValue(fields, "asset") ||
+            findFieldValue(fields, "coin_type") ||
+            findFieldValue(fields, "reserve");
+          if (asset) {
+            const formattedAsset = valueToString(asset);
+            if (formattedAsset) {
+              return formattedAsset;
+            }
+          }
+        }
+
+        if (definition && definition.name) {
+          return `${definition.name} position`;
+        }
+
+        return truncateMiddle(type, 24);
+      }
+
+      function buildProtocolPosition(objectData) {
+        if (!objectData) {
+          return null;
+        }
+
+        const type =
+          objectData.type ||
+          (objectData.content && objectData.content.type) ||
+          "";
+        if (!type || type.startsWith(COIN_TYPE_PREFIX)) {
+          return null;
+        }
+
+        const definition = identifyProtocolByType(type);
+        if (!definition) {
+          return null;
+        }
+
+        const objectId =
+          objectData.objectId ||
+          (objectData.reference && objectData.reference.objectId) ||
+          (objectData.content &&
+            objectData.content.fields &&
+            valueToString(objectData.content.fields.id)) ||
+          "";
+
+        const display = objectData.display || null;
+        const displayMetrics = createDisplayEntries(display);
+        const displayLabel = extractDisplayLabel(display);
+
+        const fields =
+          (objectData.content && objectData.content.fields) ||
+          objectData.fields ||
+          null;
+
+        const fieldMetrics = collectFieldEntries(fields, definition);
+        const metrics = [];
+        const seen = new Set();
+
+        const pushMetric = (label, value) => {
+          if (!label || !value) {
+            return;
+          }
+
+          const key = `${label}:${value}`;
+          if (seen.has(key)) {
+            return;
+          }
+
+          seen.add(key);
+          metrics.push({ label, value });
+        };
+
+        for (const metric of displayMetrics) {
+          pushMetric(metric.label, metric.value);
+          if (metrics.length >= MAX_FIELD_RESULTS) {
+            break;
+          }
+        }
+
+        if (metrics.length < MAX_FIELD_RESULTS) {
+          for (const metric of fieldMetrics) {
+            pushMetric(metric.label, metric.value);
+            if (metrics.length >= MAX_FIELD_RESULTS) {
+              break;
+            }
+          }
+        }
+
+        pushMetric("Type", truncateMiddle(type, 32));
+        if (objectId) {
+          pushMetric("Object", truncateMiddle(objectId, 16));
+        }
+
+        return {
+          protocol: definition.name,
+          label: displayLabel || deriveProtocolLabel(definition, fields, type),
+          metrics,
+          objectId,
+          type,
+        };
+      }
+
+      function createProtocolCard(position) {
+        const card = document.createElement("article");
+        card.className = "protocol-card";
+
+        const header = document.createElement("div");
+        header.className = "protocol-card-header";
+
+        const title = document.createElement("h3");
+        title.className = "protocol-card-title";
+        title.textContent = position.protocol;
+        header.appendChild(title);
+
+        if (position.label) {
+          const labelEl = document.createElement("span");
+          labelEl.className = "protocol-card-label";
+          labelEl.textContent = position.label;
+          header.appendChild(labelEl);
+        }
+
+        card.appendChild(header);
+
+        if (position.metrics && position.metrics.length) {
+          const dl = document.createElement("dl");
+          dl.className = "protocol-metrics";
+          for (const metric of position.metrics) {
+            const dt = document.createElement("dt");
+            dt.textContent = metric.label;
+            const dd = document.createElement("dd");
+            dd.textContent = metric.value;
+            dl.append(dt, dd);
+          }
+          card.appendChild(dl);
+        }
+
+        if (position.objectId) {
+          const footer = document.createElement("div");
+          footer.className = "protocol-card-footer";
+          const link = document.createElement("a");
+          link.href = `${EXPLORER_OBJECT_BASE}/${position.objectId}?network=mainnet`;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          link.textContent = "View on explorer";
+          footer.appendChild(link);
+          card.appendChild(footer);
+        }
+
+        return card;
+      }
+
+      function createProtocolSection(positions) {
+        const section = document.createElement("section");
+        section.className = "wallet-section protocol-section";
+
+        const heading = document.createElement("h2");
+        heading.className = "section-heading";
+        heading.textContent = "Protocol positions";
+        section.appendChild(heading);
+
+        if (!positions.length) {
+          const empty = document.createElement("div");
+          empty.className = "protocol-empty";
+          empty.textContent = "No protocol positions detected for this wallet.";
+          section.appendChild(empty);
+          return section;
+        }
+
+        const sorted = positions.slice().sort((a, b) => {
+          return a.protocol.localeCompare(b.protocol);
+        });
+
+        const grid = document.createElement("div");
+        grid.className = "protocol-grid";
+        for (const position of sorted) {
+          grid.appendChild(createProtocolCard(position));
+        }
+        section.appendChild(grid);
+
+        return section;
+      }
+
+      function createTransactionPanel(transactions, decimals, symbol, coinType) {
+        const panel = document.createElement("div");
+        panel.className = "transaction-panel";
+
+        const heading = document.createElement("h3");
+        heading.textContent = "Recent transactions";
+        panel.appendChild(heading);
+
+        if (!transactions.length) {
+          const empty = document.createElement("div");
+          empty.className = "tx-empty";
+          empty.textContent = "No recent balance changes found for this token.";
+          panel.appendChild(empty);
+          return panel;
+        }
+
+        const displayed = transactions.slice(0, MAX_ACTIVITY_ROWS);
+        const list = document.createElement("ul");
+        list.className = "tx-list";
+
+        for (const tx of displayed) {
+          const item = document.createElement("li");
+          item.className = "tx-item";
+
+          const amountSpan = document.createElement("span");
+          amountSpan.className = "tx-amount";
+
+          const amountValue = toNumeric(tx.amount);
+          const direction = hasBigInt
+            ? amountValue >= BIGINT_ZERO
+              ? "in"
+              : "out"
+            : amountValue >= 0
+            ? "in"
+            : "out";
+          amountSpan.classList.add(direction === "in" ? "positive" : "negative");
+
+          const absoluteValue = hasBigInt
+            ? amountValue < BIGINT_ZERO
+              ? BIGINT_ZERO - amountValue
+              : amountValue
+            : Math.abs(amountValue);
+          const absolute = hasBigInt ? absoluteValue.toString() : String(absoluteValue);
+          const formattedAmount = formatWithDecimals(absolute, decimals);
+          const tokenLabel = symbol || truncateMiddle(coinType, 12);
+          amountSpan.textContent = `${direction === "in" ? "+" : "-"}${formattedAmount} ${tokenLabel}`;
+
+          const meta = document.createElement("div");
+          meta.className = "tx-meta";
+
+          const directionLabel = document.createElement("span");
+          directionLabel.textContent = direction === "in" ? "Received" : "Sent";
+
+          const timeLabel = document.createElement("span");
+          timeLabel.textContent = formatTimestamp(tx.timestampMs);
+
+          const link = document.createElement("a");
+          link.href = `${EXPLORER_BASE}/${tx.digest}?network=mainnet`;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          link.textContent = truncateMiddle(tx.digest, 14);
+
+          meta.append(directionLabel, timeLabel, link);
+          item.append(amountSpan, meta);
+          list.appendChild(item);
+        }
+
+        panel.appendChild(list);
+        return panel;
+      }
+
+      function createTokenSection(rows, transactionsByCoin) {
+        const section = document.createElement("section");
+        section.className = "wallet-section token-section";
+
+        const heading = document.createElement("h2");
+        heading.className = "section-heading";
+        heading.textContent = "Wallet tokens";
+        section.appendChild(heading);
+
+        if (!rows.length) {
+          section.appendChild(emptyTpl.content.cloneNode(true));
+          return section;
+        }
+
+        const tableFragment = balancesTpl.content.cloneNode(true);
+        const tableElement = tableFragment.querySelector("table");
+        const tbody = tableElement.querySelector("tbody");
+
+        for (const row of rows) {
+          const tr = document.createElement("tr");
+          tr.className = "token-row";
+          const tokenCell = document.createElement("td");
+          const balanceCell = document.createElement("td");
+          const typeCell = document.createElement("td");
+          const actionCell = document.createElement("td");
+          actionCell.className = "actions";
+
+          const tokenInfo = document.createElement("div");
+          tokenInfo.className = "token-info";
+
+          const iconWrapper = document.createElement("span");
+          iconWrapper.className = "token-icon";
+          if (row.iconUrl) {
+            const img = document.createElement("img");
+            img.src = row.iconUrl;
+            img.alt = row.symbol ? `${row.symbol} logo` : "Token logo";
+            img.loading = "lazy";
+            iconWrapper.appendChild(img);
+          } else {
+            iconWrapper.textContent = row.symbol ? row.symbol.slice(0, 3) : "?";
+          }
+
+          const meta = document.createElement("div");
+          meta.className = "token-meta";
+          const symbolEl = document.createElement("span");
+          symbolEl.className = "token-symbol";
+          symbolEl.textContent = row.symbol || "Unknown";
+          meta.appendChild(symbolEl);
+          if (row.name) {
+            const nameEl = document.createElement("span");
+            nameEl.className = "token-name";
+            nameEl.textContent = row.name;
+            meta.appendChild(nameEl);
+          }
+
+          tokenInfo.append(iconWrapper, meta);
+          tokenCell.appendChild(tokenInfo);
+          balanceCell.textContent = row.displayBalance;
+          if (row.symbol) {
+            balanceCell.textContent += ` ${row.symbol}`;
+          }
+          typeCell.textContent = row.coinType;
+          typeCell.title = row.coinType;
+
+          const expandBtn = document.createElement("button");
+          expandBtn.type = "button";
+          expandBtn.className = "expand-btn";
+          expandBtn.innerHTML = `
+            <span>View activity</span>
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.22 7.22a.75.75 0 0 1 1.06 0L10 10.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 8.28a.75.75 0 0 1 0-1.06z" clip-rule="evenodd"></path>
+            </svg>
+          `;
+          expandBtn.setAttribute("aria-expanded", "false");
+          actionCell.appendChild(expandBtn);
+
+          const detailTr = document.createElement("tr");
+          const detailTd = document.createElement("td");
+          detailTd.colSpan = 4;
+          const transactions = transactionsByCoin.get(row.coinType) || [];
+          detailTd.appendChild(
+            createTransactionPanel(transactions, row.decimals, row.symbol, row.coinType)
+          );
+          detailTr.appendChild(detailTd);
+          detailTr.style.display = "none";
+
+          expandBtn.addEventListener("click", () => {
+            const isExpanded = tr.classList.toggle("expanded");
+            detailTr.style.display = isExpanded ? "table-row" : "none";
+            expandBtn.setAttribute("aria-expanded", String(isExpanded));
+            expandBtn.querySelector("span").textContent = isExpanded
+              ? "Hide activity"
+              : "View activity";
+          });
+
+          tr.append(tokenCell, balanceCell, typeCell, actionCell);
+          tbody.append(tr, detailTr);
+        }
+
+        section.appendChild(tableFragment);
+        return section;
+      }
+
+      function renderWallet(rows, transactionsByCoin, protocolPositions) {
+        results.innerHTML = "";
+
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(createTokenSection(rows, transactionsByCoin));
+        fragment.appendChild(createProtocolSection(protocolPositions));
+
+        results.appendChild(fragment);
+      }
+
+      function extractOwnerAddress(owner) {
+        if (!owner) {
+          return null;
+        }
+
+        if (typeof owner === "string") {
+          return owner;
+        }
+
+        if (owner.AddressOwner) {
+          return owner.AddressOwner;
+        }
+
+        if (owner.GasOwner) {
+          return owner.GasOwner;
+        }
+
+        if (owner.ObjectOwner) {
+          return owner.ObjectOwner;
+        }
+
+        return null;
+      }
+
+      async function getTransactions(address) {
+        if (transactionCache.has(address)) {
+          return transactionCache.get(address);
+        }
+
+        const query = {
+          filter: {
+            Any: [{ FromAddress: address }, { ToAddress: address }],
+          },
+          options: {
+            showBalanceChanges: true,
+            showEffects: true,
+            showInput: false,
+            showEvents: false,
+            showObjectChanges: false,
+          },
+        };
+
+        try {
+          const response = await fetchRpc("suix_queryTransactionBlocks", [
+            query,
+            null,
+            MAX_TRANSACTIONS,
+            true,
+          ]);
+          const transactions = response && Array.isArray(response.data)
+            ? response.data
+            : [];
+          transactionCache.set(address, transactions);
+          return transactions;
+        } catch (error) {
+          console.warn("Failed to load transactions", error);
+          transactionCache.set(address, []);
+          return [];
+        }
+      }
+
+      function groupTransactionsByCoin(transactions, address) {
+        const map = new Map();
+        const normalizedAddress = normalizeAddress(address);
+
+        for (const tx of transactions) {
+          const digest = tx.digest;
+          const timestampMs = tx.timestampMs === undefined || tx.timestampMs === null
+            ? null
+            : tx.timestampMs;
+          const balanceChanges = tx.balanceChanges || [];
+
+          for (const change of balanceChanges) {
+            const ownerAddress = normalizeAddress(extractOwnerAddress(change.owner || null) || "");
+            if (!ownerAddress || ownerAddress !== normalizedAddress) {
+              continue;
+            }
+
+            const coinType = change.coinType;
+            if (!coinType) {
+              continue;
+            }
+
+            if (change.amount === undefined || change.amount === null) {
+              continue;
+            }
+
+            if (!map.has(coinType)) {
+              map.set(coinType, []);
+            }
+
+            const entry = {
+              digest,
+              timestampMs,
+              amount: change.amount,
+            };
+            map.get(coinType).push(entry);
+          }
+        }
+
+        for (const [coinType, entries] of map.entries()) {
+          entries.sort((a, b) => {
+            const aTime = a.timestampMs ? Number(a.timestampMs) : 0;
+            const bTime = b.timestampMs ? Number(b.timestampMs) : 0;
+            return bTime - aTime;
+          });
+          map.set(coinType, entries);
+        }
+
+        return map;
+      }
+
+      async function getProtocolPositions(address) {
+        const positions = [];
+        const seenIds = new Set();
+        let cursor = null;
+        let pageCount = 0;
+
+        while (pageCount < OBJECT_PAGE_LIMIT) {
+          let response;
+          try {
+            response = await fetchRpc("suix_getOwnedObjects", [
+              address,
+              cursor,
+              OBJECT_PAGE_SIZE,
+              {
+                showType: true,
+                showContent: true,
+                showDisplay: true,
+              },
+            ]);
+          } catch (error) {
+            console.warn("Failed to load protocol positions", error);
+            break;
+          }
+
+          pageCount += 1;
+          const data = response && Array.isArray(response.data) ? response.data : [];
+          for (const entry of data) {
+            const objectData = entry && entry.data ? entry.data : entry;
+            const position = buildProtocolPosition(objectData);
+            if (!position) {
+              continue;
+            }
+
+            if (position.objectId && seenIds.has(position.objectId)) {
+              continue;
+            }
+
+            if (position.objectId) {
+              seenIds.add(position.objectId);
+            }
+
+            positions.push(position);
+          }
+
+          if (!response || !response.hasNextPage || !response.nextCursor) {
+            break;
+          }
+
+          cursor = response.nextCursor;
+        }
+
+        return positions;
+      }
+
+      async function handleSubmit(event) {
+        event.preventDefault();
+        const address = normalizeAddress(input.value);
+        if (!address) {
+          return;
+        }
+
+        status.textContent = "Fetching balances...";
+        status.style.color = "#38bdf8";
+        results.innerHTML = "";
+        form.querySelector("button").disabled = true;
+
+        try {
+          const [balances, transactions, protocolPositions] = await Promise.all([
+            getBalances(address),
+            getTransactions(address),
+            getProtocolPositions(address),
+          ]);
+          const transactionsByCoin = groupTransactionsByCoin(transactions, address);
+          const rows = await Promise.all(
+            (balances || []).map(async (balance) => {
+              const metadata = await getCoinMetadata(balance.coinType);
+              const decimalsValue = metadata && metadata.decimals !== undefined
+                ? Number(metadata.decimals)
+                : 0;
+              const safeDecimals = Number.isFinite(decimalsValue) ? decimalsValue : 0;
+              const symbol = metadata && metadata.symbol ? metadata.symbol : null;
+              const name = metadata && metadata.name ? metadata.name : null;
+              const iconUrl = metadata && metadata.iconUrl ? metadata.iconUrl : null;
+              const displayBalance = formatWithDecimals(
+                balance.totalBalance,
+                safeDecimals
+              );
+
+              return {
+                coinType: balance.coinType,
+                displayBalance,
+                symbol,
+                name,
+                iconUrl,
+                decimals: safeDecimals,
+                rawBalance: balance.totalBalance,
+              };
+            })
+          );
+
+          const sortedRows = rows
+            .sort((a, b) => {
+              try {
+                if (hasBigInt) {
+                  const diff = BigInt(b.rawBalance) - BigInt(a.rawBalance);
+                  if (diff > BIGINT_ZERO) return 1;
+                  if (diff < BIGINT_ZERO) return -1;
+                } else {
+                  const diff = Number(b.rawBalance) - Number(a.rawBalance);
+                  if (Number.isFinite(diff) && diff !== 0) {
+                    return diff > 0 ? 1 : -1;
+                  }
+                }
+              } catch (error) {
+                // ignore differences we cannot compare
+              }
+              return 0;
+            })
+            .map(({ rawBalance, ...rest }) => rest);
+
+          renderWallet(sortedRows, transactionsByCoin, protocolPositions);
+          status.textContent = `Loaded ${sortedRows.length} token${
+            sortedRows.length === 1 ? "" : "s"
+          } and ${protocolPositions.length} protocol position${
+            protocolPositions.length === 1 ? "" : "s"
+          }.`;
+          status.style.color = "#34d399";
+        } catch (error) {
+          console.error(error);
+          status.textContent = error.message || "Something went wrong.";
+          status.style.color = "#f87171";
+        } finally {
+          form.querySelector("button").disabled = false;
+        }
+      }
+
+      form.addEventListener("submit", handleSubmit);
+    </script>
+  </body>
+</html>

--- a/wallet_reader.py
+++ b/wallet_reader.py
@@ -1,0 +1,668 @@
+"""Sui wallet reader CLI.
+
+This script provides read-only access to Sui wallets by querying the public
+JSON-RPC endpoint. Given a wallet address it fetches the balances of all coins
+held by the address and prints a readable summary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+JSON_RPC_ID = 1
+
+SUI_NETWORK_ENDPOINTS: Dict[str, str] = {
+    "mainnet": "https://fullnode.mainnet.sui.io:443",
+    "testnet": "https://fullnode.testnet.sui.io:443",
+    "devnet": "https://fullnode.devnet.sui.io:443",
+}
+
+COIN_TYPE_PREFIX = "0x2::coin::Coin<"
+OBJECT_PAGE_LIMIT = 5
+OBJECT_PAGE_SIZE = 50
+MAX_FIELD_RESULTS = 6
+
+
+@dataclass
+class ProtocolDefinition:
+    """Definition used to identify and describe a protocol position."""
+
+    name: str
+    patterns: Sequence[str]
+    preferred_fields: Sequence[str]
+
+
+PROTOCOL_DEFINITIONS: Sequence[ProtocolDefinition] = (
+    ProtocolDefinition(
+        name="Cetus",
+        patterns=("::cetus", "::clmm"),
+        preferred_fields=("coin_a", "coin_b", "liquidity", "amount_a", "amount_b"),
+    ),
+    ProtocolDefinition(
+        name="Suilend",
+        patterns=("::suilend",),
+        preferred_fields=("supplied", "borrowed", "collateral", "debt"),
+    ),
+    ProtocolDefinition(
+        name="Navi Protocol",
+        patterns=("::navi",),
+        preferred_fields=("supplied", "borrowed", "collateral", "apy"),
+    ),
+    ProtocolDefinition(
+        name="Bluefin",
+        patterns=("::bluefin", "::perps", "::perpetual"),
+        preferred_fields=("side", "size", "entry_price", "leverage"),
+    ),
+)
+
+
+@dataclass
+class ProtocolMetric:
+    """Represents a labelled value describing a protocol position."""
+
+    label: str
+    value: str
+
+
+@dataclass
+class ProtocolPosition:
+    """Represents a detected protocol position owned by an address."""
+
+    protocol: str
+    label: str
+    object_id: Optional[str]
+    metrics: List[ProtocolMetric]
+
+
+@dataclass
+class CoinBalance:
+    """Represents a coin balance for a Sui address."""
+
+    coin_type: str
+    total_balance: int
+    symbol: Optional[str]
+    decimals: Optional[int]
+
+    @property
+    def display_symbol(self) -> str:
+        if self.symbol:
+            return self.symbol
+        # Derive symbol from coin type last segment if metadata is missing.
+        return self.coin_type.split("::")[-1]
+
+    def formatted_balance(self) -> str:
+        if self.decimals is None or self.decimals < 0:
+            return str(self.total_balance)
+        scaled = self.total_balance / (10 ** self.decimals)
+        return f"{scaled:,.{min(self.decimals, 9)}f}"
+
+
+@dataclass
+class BalanceChange:
+    """Represents a balance change for a specific coin type."""
+
+    digest: str
+    timestamp_ms: Optional[int]
+    amount: int
+
+    def formatted_timestamp(self) -> str:
+        if self.timestamp_ms is None:
+            return "unknown time"
+        try:
+            dt = datetime.fromtimestamp(self.timestamp_ms / 1000, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):  # pragma: no cover - platform dependent
+            return "unknown time"
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+class SuiRpcError(RuntimeError):
+    """Raised when the Sui JSON-RPC endpoint responds with an error."""
+
+
+class SuiWalletReader:
+    """Client for reading Sui wallet balances via JSON-RPC."""
+
+    def __init__(self, network: str = "mainnet") -> None:
+        if network not in SUI_NETWORK_ENDPOINTS:
+            available = ", ".join(sorted(SUI_NETWORK_ENDPOINTS))
+            raise ValueError(
+                f"Unknown network '{network}'. Available networks: {available}"
+            )
+        self.network = network
+        self.endpoint = SUI_NETWORK_ENDPOINTS[network]
+
+    def read_balances(self, address: str) -> List[CoinBalance]:
+        normalized = normalize_address(address)
+        balances = self._call_rpc("suix_getAllBalances", [normalized])
+        coins: List[CoinBalance] = []
+        for entry in balances:
+            coin_type = entry.get("coinType")
+            raw_balance = entry.get("totalBalance")
+            if coin_type is None or raw_balance is None:
+                # Skip malformed entries.
+                continue
+            metadata = self._coin_metadata(coin_type)
+            coins.append(
+                CoinBalance(
+                    coin_type=coin_type,
+                    total_balance=int(raw_balance),
+                    symbol=metadata.get("symbol") if metadata else None,
+                    decimals=metadata.get("decimals") if metadata else None,
+                )
+            )
+        return coins
+
+    def recent_balance_changes(
+        self, address: str, max_transactions: int = 50
+    ) -> Dict[str, List[BalanceChange]]:
+        normalized = normalize_address(address)
+        if not normalized:
+            return {}
+
+        query = {
+            "filter": {
+                "Any": [
+                    {"FromAddress": normalized},
+                    {"ToAddress": normalized},
+                ]
+            },
+            "options": {
+                "showBalanceChanges": True,
+                "showEffects": True,
+                "showInput": False,
+                "showEvents": False,
+                "showObjectChanges": False,
+            },
+        }
+
+        response = self._call_rpc(
+            "suix_queryTransactionBlocks",
+            [query, None, max_transactions, True],
+        )
+
+        transactions = []
+        if isinstance(response, dict):
+            data = response.get("data")
+            if isinstance(data, list):
+                transactions = data
+
+        grouped: Dict[str, List[BalanceChange]] = {}
+        for tx in transactions:
+            digest = tx.get("digest", "")
+            timestamp_raw = tx.get("timestampMs")
+            timestamp_ms = _safe_int(timestamp_raw)
+            balance_changes = tx.get("balanceChanges") or []
+            if not isinstance(balance_changes, list):
+                continue
+
+            for change in balance_changes:
+                owner = normalize_address(_extract_owner_address(change.get("owner")))
+                if not owner or owner != normalized:
+                    continue
+
+                coin_type = change.get("coinType")
+                amount_raw = change.get("amount")
+                if coin_type is None or amount_raw is None:
+                    continue
+
+                amount = _safe_int(amount_raw)
+                if amount is None:
+                    continue
+
+                grouped.setdefault(coin_type, []).append(
+                    BalanceChange(digest=digest, timestamp_ms=timestamp_ms, amount=amount)
+                )
+
+        for coin_type, entries in grouped.items():
+            entries.sort(key=lambda entry: entry.timestamp_ms or 0, reverse=True)
+            if len(entries) > 10:
+                grouped[coin_type] = entries[:10]
+
+        return grouped
+
+    def protocol_positions(self, address: str) -> List[ProtocolPosition]:
+        """Fetch protocol positions detected from owned objects."""
+
+        normalized = normalize_address(address)
+        if not normalized:
+            return []
+
+        positions: List[ProtocolPosition] = []
+        seen_ids: set[str] = set()
+        cursor: Optional[object] = None
+        page = 0
+
+        while page < OBJECT_PAGE_LIMIT:
+            params = [
+                normalized,
+                cursor,
+                OBJECT_PAGE_SIZE,
+                {"showType": True, "showContent": True, "showDisplay": True},
+            ]
+            response = self._call_rpc("suix_getOwnedObjects", params)
+
+            if not isinstance(response, dict):
+                break
+
+            data = response.get("data")
+            objects: List[object] = data if isinstance(data, list) else []
+
+            for entry in objects:
+                if isinstance(entry, dict) and "data" in entry:
+                    object_data = entry.get("data")
+                else:
+                    object_data = entry
+
+                position = build_protocol_position(object_data)
+                if not position:
+                    continue
+
+                if position.object_id and position.object_id in seen_ids:
+                    continue
+
+                if position.object_id:
+                    seen_ids.add(position.object_id)
+
+                positions.append(position)
+
+            page += 1
+            cursor = response.get("nextCursor")
+            if not response.get("hasNextPage") or cursor in (None, {}):
+                break
+
+        return positions
+
+    def _call_rpc(self, method: str, params: Iterable[object]) -> object:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": list(params),
+                "id": JSON_RPC_ID,
+            }
+        ).encode("utf-8")
+
+        request = urllib.request.Request(
+            self.endpoint, data=payload, headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except urllib.error.URLError as exc:  # pragma: no cover - network errors
+            raise ConnectionError(
+                f"Failed to connect to Sui endpoint '{self.endpoint}': {exc}"
+            ) from exc
+
+        if "error" in data:
+            error = data["error"]
+            message = error.get("message", "Unknown error")
+            raise SuiRpcError(f"RPC error calling {method}: {message}")
+        return data.get("result")
+
+    @lru_cache(maxsize=128)
+    def _coin_metadata(self, coin_type: str) -> Dict[str, object]:
+        try:
+            metadata = self._call_rpc("suix_getCoinMetadata", [coin_type])
+        except SuiRpcError:
+            # Some coins may not have metadata. Return empty dict to avoid noisy output.
+            return {}
+        if metadata is None:
+            return {}
+        return metadata
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read holdings for a Sui wallet.")
+    parser.add_argument(
+        "address",
+        help="Sui wallet address (0x...) to inspect",
+    )
+    parser.add_argument(
+        "--network",
+        default="mainnet",
+        choices=sorted(SUI_NETWORK_ENDPOINTS),
+        help="Sui network to query (default: mainnet)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    reader = SuiWalletReader(network=args.network)
+    try:
+        balances = reader.read_balances(args.address)
+        balance_changes = reader.recent_balance_changes(args.address)
+        protocol_positions = reader.protocol_positions(args.address)
+    except (ConnectionError, SuiRpcError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if not balances:
+        print("No balances found for this address.")
+        return 0
+
+    print(f"Holdings for address {args.address} on {args.network}:")
+    print("-" * 60)
+    for coin in balances:
+        amount = coin.formatted_balance()
+        symbol = coin.display_symbol
+        print(f"{symbol:<20} {amount:>20}  ({coin.coin_type})")
+
+        changes = balance_changes.get(coin.coin_type, [])
+        if not changes:
+            print("    No recent balance changes tracked.")
+            continue
+
+        for change in changes:
+            formatted_amount = format_amount(change.amount, coin.decimals)
+            direction = "received" if change.amount > 0 else "sent"
+            timestamp = change.formatted_timestamp()
+            print(
+                f"    {timestamp} · {formatted_amount} {symbol} {direction} · tx {change.digest}"
+            )
+    print("-" * 60)
+    print(f"Total coins: {len(balances)}")
+
+    print()
+    if protocol_positions:
+        print("Protocol positions:")
+        print("-" * 60)
+        for position in sorted(protocol_positions, key=lambda pos: pos.protocol):
+            label = position.label or "Unlabelled position"
+            print(f"{position.protocol}: {label}")
+            for metric in position.metrics:
+                print(f"    {metric.label}: {metric.value}")
+            if position.object_id:
+                print(f"    Object ID: {position.object_id}")
+            print("-" * 40)
+    else:
+        print("No protocol positions detected for this address.")
+
+    return 0
+
+
+def _safe_int(value: object) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_address(raw: Optional[str]) -> str:
+    if not raw:
+        return ""
+    trimmed = raw.strip().lower()
+    if not trimmed:
+        return ""
+    return trimmed if trimmed.startswith("0x") else f"0x{trimmed}"
+
+
+def _extract_owner_address(owner: object) -> Optional[str]:
+    if owner is None:
+        return None
+    if isinstance(owner, str):
+        return owner
+    if isinstance(owner, dict):
+        for key in ("AddressOwner", "GasOwner", "ObjectOwner"):
+            nested = owner.get(key)
+            if isinstance(nested, str):
+                return nested
+    return None
+
+
+def format_amount(amount: int, decimals: Optional[int]) -> str:
+    sign = "" if amount >= 0 else "-"
+    absolute = abs(amount)
+    if decimals is None or decimals <= 0:
+        return f"{sign}{absolute}"
+    scaled = absolute / (10 ** decimals)
+    if decimals > 9:
+        decimals = 9
+    formatted = f"{scaled:,.{decimals}f}".rstrip("0").rstrip(".")
+    return f"{sign}{formatted}"
+
+
+def to_title_case(value: str) -> str:
+    return " ".join(segment.capitalize() for segment in value.replace("_", " ").replace("-", " ").split())
+
+
+def value_to_string(value: object) -> Optional[str]:
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+
+    if isinstance(value, list):
+        formatted = [value_to_string(item) for item in value]
+        compact = [item for item in formatted if item]
+        return ", ".join(compact) if compact else None
+
+    if isinstance(value, dict):
+        if isinstance(value.get("id"), str):
+            return value["id"]
+        if isinstance(value.get("objectId"), str):
+            return value["objectId"]
+        if "fields" in value:
+            return value_to_string(value.get("fields"))
+
+        entries = []
+        for key, nested in value.items():
+            if len(entries) >= 2:
+                break
+            formatted = value_to_string(nested)
+            if formatted:
+                entries.append(f"{to_title_case(key)}: {formatted}")
+        return " • ".join(entries) if entries else None
+
+    return str(value)
+
+
+def extract_display_label(display: object) -> Optional[str]:
+    if not isinstance(display, dict):
+        return None
+
+    data = display.get("data") if isinstance(display.get("data"), dict) else display
+    if not isinstance(data, dict):
+        return None
+
+    for key in ("name", "title", "label"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def create_display_entries(display: object) -> List[ProtocolMetric]:
+    if not isinstance(display, dict):
+        return []
+
+    data = display.get("data") if isinstance(display.get("data"), dict) else display
+    if not isinstance(data, dict):
+        return []
+
+    metrics: List[ProtocolMetric] = []
+    for key, value in data.items():
+        if key in {"name", "title", "label"}:
+            continue
+        formatted = value_to_string(value)
+        if not formatted:
+            continue
+        metrics.append(ProtocolMetric(label=to_title_case(key), value=formatted))
+        if len(metrics) >= MAX_FIELD_RESULTS:
+            break
+    return metrics
+
+
+def shorten_type_name(value: str) -> str:
+    without_generics = value.split("<", 1)[0]
+    parts = without_generics.split("::")
+    return parts[-1] if parts else value
+
+
+def find_field_value(fields: object, target_key: str) -> Optional[object]:
+    if isinstance(fields, dict):
+        if target_key in fields:
+            return fields[target_key]
+        for nested in fields.values():
+            result = find_field_value(nested, target_key)
+            if result is not None:
+                return result
+    elif isinstance(fields, list):
+        for item in fields:
+            result = find_field_value(item, target_key)
+            if result is not None:
+                return result
+    return None
+
+
+def collect_field_entries(
+    fields: object, definition: Optional[ProtocolDefinition]
+) -> List[ProtocolMetric]:
+    if not isinstance(fields, dict):
+        return []
+
+    metrics: List[ProtocolMetric] = []
+    seen: set[Tuple[str, str]] = set()
+
+    def add_metric(label: str, value: str) -> None:
+        key = (label.lower(), value)
+        if key in seen:
+            return
+        seen.add(key)
+        metrics.append(ProtocolMetric(label=label, value=value))
+
+    preferred = definition.preferred_fields if definition else []
+    for key in preferred:
+        formatted = value_to_string(find_field_value(fields, key))
+        if not formatted:
+            continue
+        add_metric(to_title_case(key), formatted)
+        if len(metrics) >= MAX_FIELD_RESULTS:
+            return metrics
+
+    for key, value in fields.items():
+        formatted = value_to_string(value)
+        if not formatted:
+            continue
+        add_metric(to_title_case(key), formatted)
+        if len(metrics) >= MAX_FIELD_RESULTS:
+            break
+
+    return metrics
+
+
+def derive_protocol_label(
+    definition: Optional[ProtocolDefinition], fields: object, type_name: str
+) -> str:
+    if isinstance(fields, dict):
+        coin_a = find_field_value(fields, "coin_a") or find_field_value(fields, "coinA") or find_field_value(fields, "token_a")
+        coin_b = find_field_value(fields, "coin_b") or find_field_value(fields, "coinB") or find_field_value(fields, "token_b")
+        if coin_a and coin_b:
+            formatted_a = value_to_string(coin_a) or shorten_type_name(str(coin_a))
+            formatted_b = value_to_string(coin_b) or shorten_type_name(str(coin_b))
+            if formatted_a and formatted_b:
+                return f"{shorten_type_name(formatted_a)} / {shorten_type_name(formatted_b)}"
+
+        market = find_field_value(fields, "market") or find_field_value(fields, "pool_id") or find_field_value(fields, "pool")
+        if market:
+            formatted_market = value_to_string(market)
+            if formatted_market:
+                return formatted_market
+
+        asset = find_field_value(fields, "asset") or find_field_value(fields, "coin_type") or find_field_value(fields, "reserve")
+        if asset:
+            formatted_asset = value_to_string(asset)
+            if formatted_asset:
+                return formatted_asset
+
+    if definition:
+        return f"{definition.name} position"
+    return shorten_type_name(type_name)
+
+
+def identify_protocol_by_type(type_name: str) -> Optional[ProtocolDefinition]:
+    lower = type_name.lower()
+    for definition in PROTOCOL_DEFINITIONS:
+        if any(pattern in lower for pattern in definition.patterns):
+            return definition
+    return None
+
+
+def build_protocol_position(object_data: object) -> Optional[ProtocolPosition]:
+    if not isinstance(object_data, dict):
+        return None
+
+    type_name = (
+        object_data.get("type")
+        or (object_data.get("content") or {}).get("type")
+        or ""
+    )
+    if not type_name or type_name.startswith(COIN_TYPE_PREFIX):
+        return None
+
+    definition = identify_protocol_by_type(type_name)
+    if not definition:
+        return None
+
+    object_id = (
+        object_data.get("objectId")
+        or (object_data.get("reference") or {}).get("objectId")
+        or ((object_data.get("content") or {}).get("fields") or {}).get("id")
+    )
+    if isinstance(object_id, dict):
+        object_id = value_to_string(object_id)
+
+    display = object_data.get("display")
+    display_metrics = create_display_entries(display)
+    display_label = extract_display_label(display)
+
+    fields = (
+        (object_data.get("content") or {}).get("fields")
+        or object_data.get("fields")
+        or None
+    )
+    field_metrics = collect_field_entries(fields, definition)
+
+    metrics: List[ProtocolMetric] = []
+    seen: set[Tuple[str, str]] = set()
+    for collection in (display_metrics, field_metrics):
+        for metric in collection:
+            key = (metric.label.lower(), metric.value)
+            if key in seen:
+                continue
+            seen.add(key)
+            metrics.append(metric)
+            if len(metrics) >= MAX_FIELD_RESULTS:
+                break
+        if len(metrics) >= MAX_FIELD_RESULTS:
+            break
+
+    label = display_label or derive_protocol_label(definition, fields, type_name)
+
+    return ProtocolPosition(
+        protocol=definition.name,
+        label=label,
+        object_id=object_id if isinstance(object_id, str) else None,
+        metrics=metrics,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add protocol detection helpers and owned-object pagination so the CLI surfaces DeFi protocol positions alongside balances
- reuse shared formatting helpers to display per-position metrics and explorer context in the console output
- document the updated CLI behaviour and usage in the README

## Testing
- python -m compileall wallet_reader.py

------
https://chatgpt.com/codex/tasks/task_e_68e60a6cd11c832f8775568346222cde